### PR TITLE
updated YC rounds and removed box borders from disabled input boxes

### DIFF
--- a/src/app/cap-table/Worksheet.tsx
+++ b/src/app/cap-table/Worksheet.tsx
@@ -21,7 +21,7 @@ import { getPricedRoundCapTablePropsSelector, getSafeCapTablePropsSelector } fro
 import { getShareUrl } from "./state/selectors/ShareURLSelector";
 import { getErrorSelector } from "./state/selectors/ErrorSelector";
 import Finder from "@/components/safe-conversion/Conversion/Finder";
-import { FolderPlusIcon } from "@heroicons/react/24/outline";
+import { ArrowPathIcon, FolderPlusIcon } from "@heroicons/react/24/outline";
 import { localStorageWorks } from "./state/localstorage";
 
 type WorksheetProps = {
@@ -65,10 +65,10 @@ const Worksheet: React.FC<WorksheetProps> = ({conversionState, currentStateId, l
           <Finder currentId={currentStateId} loadById={loadById}></Finder>
         }
         <button
-          className={`w-24 px-4 text-center cursor-pointer py-2  focus:outline-none focus:ring-2 text-white bg-nt84blue hover:bg-nt84bluedarker inline`}
+          className={`w-26 px-4 text-center cursor-pointer py-2 focus:outline-none focus:ring-2 text-white bg-nt84blue hover:bg-nt84bluedarker inline`}
           onClick={() => createNewState(false)}
         >
-          New <FolderPlusIcon className="inline" width={20} />
+          Reset<ArrowPathIcon className="inline pl-2" width={20} />
         </button>
       </div>
       <h1 className="text-2xl font-bold mb-12 pl-2">1 Existing Cap Table</h1>

--- a/src/app/cap-table/Worksheet.tsx
+++ b/src/app/cap-table/Worksheet.tsx
@@ -21,7 +21,7 @@ import { getPricedRoundCapTablePropsSelector, getSafeCapTablePropsSelector } fro
 import { getShareUrl } from "./state/selectors/ShareURLSelector";
 import { getErrorSelector } from "./state/selectors/ErrorSelector";
 import Finder from "@/components/safe-conversion/Conversion/Finder";
-import { ArrowPathIcon, FolderPlusIcon } from "@heroicons/react/24/outline";
+import { ArrowPathIcon } from "@heroicons/react/24/outline";
 import { localStorageWorks } from "./state/localstorage";
 
 type WorksheetProps = {

--- a/src/app/cap-table/state/ConversionState.ts
+++ b/src/app/cap-table/state/ConversionState.ts
@@ -15,7 +15,7 @@ export type ExistingShareholderState = Pick<
 >;
 export type SAFEState = Pick<
   SAFEProps,
-  "id" | "type" | "name" | "investment" | "cap" | "discount" | "conversionType"
+  "id" | "type" | "name" | "investment" | "cap" | "discount" | "conversionType" | "conversionDisplay" 
 >;
 export type SeriesState = Pick<
   SeriesProps,
@@ -116,6 +116,7 @@ export const createConversionStore = (initialState: IConversionStateData) =>
               cap: 0,
               discount: 0,
               conversionType: "post",
+              conversionDisplay: "post"
             },
           ],
         }));
@@ -240,6 +241,7 @@ export const getPricedConversion = createSelector(
             cap: stringToNumber(row.cap),
             discount: stringToNumber(row.discount) / 100,
             conversionType: row.conversionType,
+            conversionDisplay: row.conversionDisplay
           };
         },
       ),

--- a/src/app/cap-table/state/ConversionState.ts
+++ b/src/app/cap-table/state/ConversionState.ts
@@ -15,7 +15,7 @@ export type ExistingShareholderState = Pick<
 >;
 export type SAFEState = Pick<
   SAFEProps,
-  "id" | "type" | "name" | "investment" | "cap" | "discount" | "conversionType" | "conversionDisplay" 
+  "id" | "type" | "name" | "investment" | "cap" | "discount" | "conversionType" 
 >;
 export type SeriesState = Pick<
   SeriesProps,
@@ -116,7 +116,6 @@ export const createConversionStore = (initialState: IConversionStateData) =>
               cap: 0,
               discount: 0,
               conversionType: "post",
-              conversionDisplay: "post"
             },
           ],
         }));
@@ -240,8 +239,7 @@ export const getPricedConversion = createSelector(
             investment: stringToNumber(row.investment),
             cap: stringToNumber(row.cap),
             discount: stringToNumber(row.discount) / 100,
-            conversionType: row.conversionType,
-            conversionDisplay: row.conversionDisplay
+            conversionType: row.conversionType
           };
         },
       ),

--- a/src/app/cap-table/state/__tests__/fixtures/state_fixtures.json
+++ b/src/app/cap-table/state/__tests__/fixtures/state_fixtures.json
@@ -25,7 +25,7 @@
       "investment": 125000,
       "discount": 0,
       "cap": 1785714.2857142854,
-      "conversionType": "post"
+      "conversionType": "yc7p"
     },
     {
       "id": "4",
@@ -34,7 +34,7 @@
       "investment": 375000,
       "discount": 0,
       "cap": 0,
-      "conversionType": "mfn"
+      "conversionType": "ycmfn"
     },
     {
       "id": "5",

--- a/src/app/cap-table/state/initialState.ts
+++ b/src/app/cap-table/state/initialState.ts
@@ -60,6 +60,7 @@ export const initialState = ({
       discount: 0,
       cap: 125_000 / 0.07,
       conversionType: "post",
+      conversionDisplay: "yc7p"
     },
     // Uncapped YC MFN SAFE (Cap to best cap of all safes)
     {
@@ -70,6 +71,7 @@ export const initialState = ({
       discount: 0,
       cap: 0,
       conversionType: "mfn",
+      conversionDisplay: "ycmfn"
     },
     {
       id: getID(),
@@ -79,6 +81,7 @@ export const initialState = ({
       discount: 0,
       cap: 10_000_000,
       conversionType: "post",
+      conversionDisplay: "post"
     },
     {
       id: getID(),
@@ -88,6 +91,7 @@ export const initialState = ({
       discount: 0,
       cap: 10_000_000,
       conversionType: "post",
+      conversionDisplay: "post"
     },
     {
       id: getID(),
@@ -97,6 +101,7 @@ export const initialState = ({
       discount: 0,
       cap: 13_000_000,
       conversionType: "post",
+      conversionDisplay: "post"
     },
     {
       id: getID(),

--- a/src/app/cap-table/state/initialState.ts
+++ b/src/app/cap-table/state/initialState.ts
@@ -59,8 +59,7 @@ export const initialState = ({
       investment: 125_000,
       discount: 0,
       cap: 125_000 / 0.07,
-      conversionType: "post",
-      conversionDisplay: "yc7p"
+      conversionType: "yc7p",
     },
     // Uncapped YC MFN SAFE (Cap to best cap of all safes)
     {
@@ -70,8 +69,7 @@ export const initialState = ({
       investment: 375_000,
       discount: 0,
       cap: 0,
-      conversionType: "mfn",
-      conversionDisplay: "ycmfn"
+      conversionType: "ycmfn",
     },
     {
       id: getID(),
@@ -81,7 +79,6 @@ export const initialState = ({
       discount: 0,
       cap: 10_000_000,
       conversionType: "post",
-      conversionDisplay: "post"
     },
     {
       id: getID(),
@@ -91,7 +88,6 @@ export const initialState = ({
       discount: 0,
       cap: 10_000_000,
       conversionType: "post",
-      conversionDisplay: "post"
     },
     {
       id: getID(),
@@ -101,7 +97,6 @@ export const initialState = ({
       discount: 0,
       cap: 13_000_000,
       conversionType: "post",
-      conversionDisplay: "post"
     },
     {
       id: getID(),

--- a/src/app/cap-table/state/selectors/CapTablePropsSelector.ts
+++ b/src/app/cap-table/state/selectors/CapTablePropsSelector.ts
@@ -18,8 +18,9 @@ const optionsPoolRefreshRow = (current: BestFit, previous: BestFit): CapTableRow
   const currentOwnershipPct= (current.totalOptions / current.totalShares) * 100
   const previousOwnershipPct= (previous.totalOptions / previous.totalShares) * 100
   return {
-    name: "Options Pool Refresh",
+    name: "Options Pool Available",
     shares: current.totalOptions,
+    pps: 0,
     ownershipPct: currentOwnershipPct,
     ownershipChange: currentOwnershipPct - previousOwnershipPct,
   }
@@ -43,6 +44,7 @@ export const getPricedRoundCapTablePropsSelector = createSelector(
         name: row.name,
         shares: row.shares,
         investment: row.investment,
+        pps: row.pps,
         ownershipPct: row.ownershipPct,
         ownershipChange: row.ownershipChange,
         error: hasError,
@@ -83,6 +85,7 @@ export const getSafeCapTablePropsSelector = createSelector(
           name: shareholder.name,
           shares: shareholder.shares,
           ownershipPct: shareholder.ownership[1].percent,
+          pps: 0,
           ownershipChange: 0,
         });
       } else if (shareholder.type === "safe") {
@@ -90,6 +93,7 @@ export const getSafeCapTablePropsSelector = createSelector(
           name: shareholder.name,
           shares: shareholder.shares,
           investment: shareholder.investment,
+          pps: shareholder.ownership[0].pps,
           ownershipPct: shareholder.ownership[0].percent,
           ownershipChange: 0,
           error: shareholder.ownership[0].note?.error === "Error",

--- a/src/app/cap-table/state/selectors/PricedRoundPropsSelector.ts
+++ b/src/app/cap-table/state/selectors/PricedRoundPropsSelector.ts
@@ -24,6 +24,7 @@ const buildPricedRoundShareholderProps = (
           capTableRows.push({
             name: shareholder.name,
             shares: shareholder.shares,
+            pps: 0,
             ownershipPct: shareholder.ownership[2].percent,
             ownershipChange: shareholder.ownership[2].percent - prevShareholder.ownership[2].percent,
           });
@@ -34,6 +35,7 @@ const buildPricedRoundShareholderProps = (
         capTableRows.push({
           name: shareholder.name,
           shares: shareholder.ownership[1].shares,
+          pps: shareholder.ownership[1].pps,
           investment: shareholder.investment,
           ownershipPct: shareholder.ownership[1].percent,
           ownershipChange: shareholder.ownership[1].percent - prevShareholder.ownership[1].percent,
@@ -43,6 +45,7 @@ const buildPricedRoundShareholderProps = (
         capTableRows.push({
           name: shareholder.name,
           shares: shareholder.ownership[0].shares,
+          pps: shareholder.ownership[0].pps,
           investment: shareholder.investment,
           ownershipPct: shareholder.ownership[0].percent,
           ownershipChange: shareholder.ownership[0].percent - prevShareholder.ownership[0].percent,

--- a/src/app/cap-table/state/selectors/SAFEPropsSelector.ts
+++ b/src/app/cap-table/state/selectors/SAFEPropsSelector.ts
@@ -70,9 +70,8 @@ export const getSAFERowPropsSelector = createSelector(
           },
         ],
         allowDelete: true,
-        disabledFields: row.conversionType === "mfn" ? ["cap"] : [],
-        conversionType: row.conversionType,
-        conversionDisplay: row.conversionDisplay,
+        disabledFields: (row.conversionType === "mfn" || row.conversionType === "ycmfn") ? ["cap"] : [],
+        conversionType: row.conversionType
       };
       return {
         ...rowResult,

--- a/src/app/cap-table/state/selectors/SAFEPropsSelector.ts
+++ b/src/app/cap-table/state/selectors/SAFEPropsSelector.ts
@@ -70,6 +70,7 @@ export const getSAFERowPropsSelector = createSelector(
         allowDelete: true,
         disabledFields: row.conversionType === "mfn" ? ["cap"] : [],
         conversionType: row.conversionType,
+        conversionDisplay: row.conversionDisplay,
       };
       return {
         ...rowResult,

--- a/src/app/cap-table/state/selectors/SAFEPropsSelector.ts
+++ b/src/app/cap-table/state/selectors/SAFEPropsSelector.ts
@@ -3,6 +3,7 @@ import {
   getPricedConversion,
   IConversionStateData,
   IRowState,
+  SAFEState,
 } from "../ConversionState";
 import { calcSAFEs } from "@/utils/rowDataHelper";
 import { SAFEProps } from "@/components/safe-conversion/Conversion/SafeNoteList";
@@ -38,6 +39,14 @@ const determineRowNote = (
   }
 };
 
+const determineRowDisabledFields = (row: SAFEState) => {
+  if (row.conversionType === "mfn") return ["cap"]
+  if (row.conversionType === "ycmfn") return ["cap", "discount", "investment"]
+  if (row.conversionType === "yc7p") return ["cap", "discount", "investment"]
+  return []
+}
+
+
 export const getSAFERowPropsSelector = createSelector(
   getPricedConversion,
   (state: IConversionStateData) => state.rowData,
@@ -70,7 +79,7 @@ export const getSAFERowPropsSelector = createSelector(
           },
         ],
         allowDelete: true,
-        disabledFields: (row.conversionType === "mfn" || row.conversionType === "ycmfn") ? ["cap"] : [],
+        disabledFields: determineRowDisabledFields(row),
         conversionType: row.conversionType
       };
       return {

--- a/src/app/cap-table/state/selectors/SAFEPropsSelector.ts
+++ b/src/app/cap-table/state/selectors/SAFEPropsSelector.ts
@@ -60,11 +60,13 @@ export const getSAFERowPropsSelector = createSelector(
             percent: safeCalcs[idx][0][0],
             shares: 0,
             note: determineRowNote(row, safeCalcs[idx][0][1]),
+            pps: safeCalcs[idx][0][2],
           },
           // This is the post-conversion ownership after the priced round
           {
             percent: safeCalcs[idx][1][0],
             shares: safeCalcs[idx][1][2],
+            pps: safeCalcs[idx][1][3],
           },
         ],
         allowDelete: true,

--- a/src/app/cap-table/state/selectors/SeriesPropsSelector.ts
+++ b/src/app/cap-table/state/selectors/SeriesPropsSelector.ts
@@ -10,7 +10,7 @@ export const getSeriesPropsSelector = createSelector(
     const seriesOwnershipPct = rows.map((data) => {
       if (!pricedConversion) return [0, 0];
       const shares = Math.floor(data.investment / pricedConversion.pps);
-      return [shares, (shares / pricedConversion.totalShares) * 100];
+      return [shares, (shares / pricedConversion.totalShares) * 100, pricedConversion.pps];
     });
 
     return rows.map((row, idx) => {
@@ -22,6 +22,7 @@ export const getSeriesPropsSelector = createSelector(
         ownership: [{
           shares: seriesOwnershipPct[idx][0] ?? 0,
           percent: seriesOwnershipPct[idx][1] ?? 0,
+          pps: seriesOwnershipPct[idx][2] ?? 0,
         }],
         allowDelete: rows.length > 1,
       };

--- a/src/app/cap-table/state/selectors/__tests__/ExistingShareholderSelector.test.ts
+++ b/src/app/cap-table/state/selectors/__tests__/ExistingShareholderSelector.test.ts
@@ -4,7 +4,7 @@ import {
   IConversionStateData,
 } from "@/cap-table/state/ConversionState";
 import { getExistingShareholderPropsSelector } from "@/cap-table/state/selectors/ExistingShareholderPropsSelector";
-import fixtureData from "./fixtures/state_fixtures.json";
+import fixtureData from "../../__tests__/fixtures/state_fixtures.json";
 
 describe("Existing Shareholder Selector", () => {
   test("Basic sanity check of selector", () => {

--- a/src/app/cap-table/state/selectors/__tests__/PricedRoundSelector.test.ts
+++ b/src/app/cap-table/state/selectors/__tests__/PricedRoundSelector.test.ts
@@ -3,8 +3,8 @@ import {
   createConversionStore,
   IConversionStateData,
 } from "@/cap-table/state/ConversionState";
-import { getPriceRoundPropsSelector } from "../selectors/PricedRoundPropsSelector";
-import fixtureData from "./fixtures/state_fixtures.json";
+import { getPriceRoundPropsSelector } from "../PricedRoundPropsSelector";
+import fixtureData from "../../__tests__/fixtures/state_fixtures.json";
 
 // Test our Result Selector, which handles both showing the resulting cap table and allow users to play around with the pre-money and investment changes
 describe("Result Selector", () => {

--- a/src/app/cap-table/state/selectors/__tests__/SAFEPropsSelector.test.ts
+++ b/src/app/cap-table/state/selectors/__tests__/SAFEPropsSelector.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  createConversionStore,
+  IConversionStateData,
+} from "@/cap-table/state/ConversionState";
+import { getSAFERowPropsSelector } from "@/cap-table/state/selectors/SAFEPropsSelector";
+import fixtureData from "../../__tests__/fixtures/state_fixtures.json";
+
+describe("SAFE Props selector behaviour", () => {
+  test("Basic sanity check of selector", () => {
+    const store = createConversionStore(fixtureData as IConversionStateData);
+    const safeNotes = getSAFERowPropsSelector(
+      store.getState(),
+    );
+    expect(safeNotes[0].ownership[0].percent.toFixed(2)).toEqual("7.00");
+  });
+  test("Handle special SAFE notes and their disabled fields", () => {
+    const store = createConversionStore(fixtureData as IConversionStateData);
+    const safeNotes = getSAFERowPropsSelector(
+      store.getState(),
+    );
+    expect(safeNotes[0].ownership[0].percent.toFixed(2)).toEqual("7.00");
+    expect(safeNotes[0].disabledFields?.sort()).toEqual(["cap", "discount", "investment"].sort());
+  });
+});

--- a/src/app/components/safe-conversion/Conversion/CapTableResults.tsx
+++ b/src/app/components/safe-conversion/Conversion/CapTableResults.tsx
@@ -5,6 +5,7 @@ export interface CapTableRow {
   name: string;
   shares?: number;
   investment?: number;
+  pps?: number;
   ownershipPct: number;
   ownershipChange?: number;
   error?: boolean
@@ -45,6 +46,7 @@ export const CapTableResults: React.FC<CapTableProps> = (props) => {
             <tr className="text-gray-500">
               <th className="py-3 px-4 text-left font-thin">Shareholder / Investor</th>
               <th className="py-3 px-4 text-left font-thin">Investment</th>
+              <th className="py-3 px-4 text-left font-thin">PPS</th>
               <th className="py-3 px-4 text-left font-thin">Shares</th>
               <th className="py-3 px-4 text-left font-thin">Ownership %</th>
               {hasChanges && <th className="py-3 px-4 text-left font-thin">Change %</th>}
@@ -60,6 +62,14 @@ export const CapTableResults: React.FC<CapTableProps> = (props) => {
                   {shareholder.investment
                     ? "$" + formatNumberWithCommas(shareholder.investment)
                     : ""}
+                </td>
+                <td className="py-3 px-4 text-left border-b border-gray-300 dark:border-gray-700">
+                {ownershipError
+                    ? "Error"
+                    : shareholder.pps
+                      ? "$" + formatNumberWithCommas(shareholder.pps)
+                      : ""
+                  }
                 </td>
                 <td className="py-3 px-4 text-left border-b border-gray-300 dark:border-gray-700">
                   {ownershipError
@@ -87,6 +97,8 @@ export const CapTableResults: React.FC<CapTableProps> = (props) => {
               <td className="py-3 px-4 text-left">Total</td>
               <td className="py-3 px-4 text-left">
                 ${formatNumberWithCommas(totalInvestedToDate)}
+              </td>
+              <td className="py-3 px-4 text-left">
               </td>
               <td className="py-3 px-4 text-left">
                 {formatNumberWithCommas(totalShares)}

--- a/src/app/components/safe-conversion/Conversion/ExistingShareholders.tsx
+++ b/src/app/components/safe-conversion/Conversion/ExistingShareholders.tsx
@@ -102,7 +102,7 @@ const ExistingShareholderRow: React.FC<ExistingShareholderRowProps> = ({
         value={data.name}
         onChange={handleInputChange}
         placeholder="Common Shareholder Name"
-        className="w-48 px-3 py-2 border focus:outline-none focus:ring-2 focus:ring-blue-500"
+        className={disableNameEdit ? "w-48 px-3 py-2 border-none border-b-1 pb-1 py-2 border-b-gray-300 dark:border-b-gray-700"  : "w-48 px-3 py-2 border focus:outline-none focus:ring-2 focus:ring-blue-500"}
       />
       <CurrencyInput
         type="text"

--- a/src/app/components/safe-conversion/Conversion/Finder.tsx
+++ b/src/app/components/safe-conversion/Conversion/Finder.tsx
@@ -13,7 +13,7 @@ const Finder: React.FC<{currentId: string, loadById: (id: string) => void}> = ({
   const buttonText = () => {
     return (
       <span>
-        Recent
+        History
         <span className="inline">
           <ClockIcon className="inline pl-2" width={20} />
         </span>

--- a/src/app/components/safe-conversion/Conversion/SafeNoteList.tsx
+++ b/src/app/components/safe-conversion/Conversion/SafeNoteList.tsx
@@ -47,9 +47,9 @@ const SAFEInputRow: React.FC<SAFEInputRowProps> = ({
   ) => {
     const { name, value } = e.target;
     if (value === "yc7p") {
-      onUpdate({ ...data, ["name"]: "YC 7%", ["investment"]: 125_000, ["cap"]: 125_000 / 0.07, ["conversionType"]: "yc7p"});
+      onUpdate({ ...data, "name": "YC 7%", "investment": 125_000, "cap": 125_000 / 0.07, "conversionType": "yc7p"});
     } else if (value === "ycmfn") {
-      onUpdate({ ...data, ["name"]: "YC MFN", ["investment"]: 375_000, ["cap"]: 0 , ["conversionType"]: "ycmfn"});
+      onUpdate({ ...data, "name": "YC MFN", "investment": 375_000, "cap": 0, "conversionType": "ycmfn"});
     } else  {
       onUpdate({ ...data, [name]: value})
     }
@@ -93,7 +93,7 @@ const SAFEInputRow: React.FC<SAFEInputRowProps> = ({
         onValueChange={onValueChange}
         placeholder="Investment"
         autoComplete="off"
-        className="w-36 px-3 py-2 border  focus:outline-none focus:ring-2 focus:ring-blue-500"
+        className={data.disabledFields?.includes("investment") ? "w-36 px-3 py-2 border-b border-b-gray border-none" : "w-36 px-3 py-2 border  focus:outline-none focus:ring-2 focus:ring-blue-500"}
         prefix="$"
         allowDecimals={false}
       />
@@ -116,7 +116,7 @@ const SAFEInputRow: React.FC<SAFEInputRowProps> = ({
         value={data.discount ?? "0"}
         onValueChange={onValueChange}
         placeholder="Discount %"
-        className="w-20 px-3 py-2 border  focus:outline-none focus:ring-2 focus:ring-blue-500 text-right"
+        className={data.disabledFields?.includes("discount") ? "w-36 px-3 py-2 border-b border-b-gray border-none" : "w-36 px-3 py-2 border  focus:outline-none focus:ring-2 focus:ring-blue-500"}
         autoComplete="off"
         prefix=""
         suffix="%"

--- a/src/app/components/safe-conversion/Conversion/SafeNoteList.tsx
+++ b/src/app/components/safe-conversion/Conversion/SafeNoteList.tsx
@@ -13,6 +13,7 @@ export interface SAFEProps {
   cap: number;
   discount: number;
   conversionType: "post" | "pre" | "mfn";
+  conversionDisplay: "post" | "pre" | "mfn" | "yc7p" | "ycmfn";
   ownership: {
     shares?: number
     percent: number;
@@ -49,8 +50,8 @@ const SAFEInputRow: React.FC<SAFEInputRowProps> = ({
       onUpdate({ ...data, ["name"]: "YC 7%", ["investment"]: 125_000, ["cap"]: 125_000 / 0.07, ["conversionType"]: "post" });
     } else if (value === "ycmfn") {
       onUpdate({ ...data, ["name"]: "YC MFN", ["investment"]: 375_000, ["cap"]: 0, ["conversionType"]: "mfn" });
-    } else {
-      onUpdate({ ...data, [name]: value });
+    } else if (value === "post" || value === "pre" || value === "mfn") {
+      onUpdate({ ...data, [name]: value, ["conversionType"]: value})
     }
   };
 
@@ -103,7 +104,7 @@ const SAFEInputRow: React.FC<SAFEInputRowProps> = ({
         onValueChange={onValueChange}
         placeholder="Valuation Cap"
         autoComplete="off"
-        className="w-36 px-3 py-2 border  focus:outline-none focus:ring-2 focus:ring-blue-500"
+        className={data.disabledFields?.includes("cap") ? "w-36 px-3 py-2 border-b border-b-gray border-none" : "w-36 px-3 py-2 border  focus:outline-none focus:ring-2 focus:ring-blue-500"}
         prefix="$"
         decimalScale={0}
         allowDecimals={true}
@@ -126,16 +127,16 @@ const SAFEInputRow: React.FC<SAFEInputRowProps> = ({
       />
       {data.discount > 99 && <p className="text-red-500">Invalid discount</p>}
       <select
-        name="conversionType"
-        value={data.conversionType}
+        name="conversionDisplay"
+        value={data.conversionDisplay}
         onChange={handleDropDownChange}
         className="w-36 px-3 py-2 border  focus:outline-none focus:ring-2 focus:ring-blue-500"
       >
         <option value="post">Post Money</option>
         <option value="pre">Pre Money</option>
         <option value="mfn">Uncapped MFN</option>
-        <option value="yc7p">YC 7%</option>
-        <option value="ycmfn">YC MFN</option>
+        <option value="yc7p">YC $125K/7%</option>
+        <option value="ycmfn">YC $375K/MFN</option>
       </select>
       <div className="w-24 border-b py-2 border-gray-300 dark:border-gray-700">
         <PercentNote pct={data.ownership[0].percent} note={data.ownership[0].note} />

--- a/src/app/components/safe-conversion/Conversion/SafeNoteList.tsx
+++ b/src/app/components/safe-conversion/Conversion/SafeNoteList.tsx
@@ -12,8 +12,7 @@ export interface SAFEProps {
   investment: number;
   cap: number;
   discount: number;
-  conversionType: "post" | "pre" | "mfn";
-  conversionDisplay: "post" | "pre" | "mfn" | "yc7p" | "ycmfn";
+  conversionType: "post" | "pre" | "mfn" | "yc7p" | "ycmfn";
   ownership: {
     shares?: number
     percent: number;
@@ -48,11 +47,11 @@ const SAFEInputRow: React.FC<SAFEInputRowProps> = ({
   ) => {
     const { name, value } = e.target;
     if (value === "yc7p") {
-      onUpdate({ ...data, ["name"]: "YC 7%", ["investment"]: 125_000, ["cap"]: 125_000 / 0.07, ["conversionType"]: "post" });
+      onUpdate({ ...data, ["name"]: "YC 7%", ["investment"]: 125_000, ["cap"]: 125_000 / 0.07, ["conversionType"]: "yc7p"});
     } else if (value === "ycmfn") {
-      onUpdate({ ...data, ["name"]: "YC MFN", ["investment"]: 375_000, ["cap"]: 0, ["conversionType"]: "mfn" });
-    } else if (value === "post" || value === "pre" || value === "mfn") {
-      onUpdate({ ...data, [name]: value, ["conversionType"]: value})
+      onUpdate({ ...data, ["name"]: "YC MFN", ["investment"]: 375_000, ["cap"]: 0 , ["conversionType"]: "ycmfn"});
+    } else  {
+      onUpdate({ ...data, [name]: value})
     }
   };
 
@@ -128,8 +127,8 @@ const SAFEInputRow: React.FC<SAFEInputRowProps> = ({
       />
       {data.discount > 99 && <p className="text-red-500">Invalid discount</p>}
       <select
-        name="conversionDisplay"
-        value={data.conversionDisplay}
+        name="conversionType"
+        value={data.conversionType}
         onChange={handleDropDownChange}
         className="w-36 px-3 py-2 border  focus:outline-none focus:ring-2 focus:ring-blue-500"
       >

--- a/src/app/components/safe-conversion/Conversion/SafeNoteList.tsx
+++ b/src/app/components/safe-conversion/Conversion/SafeNoteList.tsx
@@ -18,6 +18,7 @@ export interface SAFEProps {
     shares?: number
     percent: number;
     note?: OwnershipPctNotes
+    pps?: number
   } [];
   allowDelete?: boolean;
   shares?: number;

--- a/src/app/components/safe-conversion/Conversion/SeriesInvestorList.tsx
+++ b/src/app/components/safe-conversion/Conversion/SeriesInvestorList.tsx
@@ -11,6 +11,7 @@ export interface SeriesProps {
   ownership: {
     shares?: number;
     percent: number;
+    pps: number;
     error?: string | undefined;
     reason?: string | undefined;
   }[];

--- a/src/app/utils/rowDataHelper.ts
+++ b/src/app/utils/rowDataHelper.ts
@@ -11,7 +11,7 @@ const getMFNCapAter = (rows: SAFEState[], idx: number): number => {
     rows.slice(idx + 1).reduce((val, row) => {
 
       // Ignore anything that's in MFN
-      if (row.conversionType === "mfn") {
+      if (row.conversionType === "mfn" || row.conversionType === "ycmfn") {
         return val;
       }
 
@@ -39,7 +39,7 @@ const getMFNCapAter = (rows: SAFEState[], idx: number): number => {
 // like MFN on safes and ownership percentages at various stages
 const getCapForSafe = (safe: SAFEState, safes: SAFEState[]): number => {
   const idx = safes.findIndex((r) => r.id === safe.id);
-  if (safe.conversionType === "mfn") {
+  if (safe.conversionType === "mfn" || safe.conversionType === "ycmfn") {
     return getMFNCapAter(safes, idx);
   }
   return safe.cap;

--- a/src/app/utils/rowDataHelper.ts
+++ b/src/app/utils/rowDataHelper.ts
@@ -50,7 +50,7 @@ const getCapForSafe = (safe: SAFEState, safes: SAFEState[]): number => {
 export const calcSAFEs = (
   rowData: IRowState[],
   pricedConversion: BestFit,
-): [pct: number, cap: number, shares: number][][] => {
+): [pct: number, cap: number, shares: number, pps: number][][] => {
   const rows = rowData.filter((row) => row.type === "safe");
 
   const safeCaps = rows.map((safe) => {
@@ -61,7 +61,7 @@ export const calcSAFEs = (
   // Both pre and post conversion
   return rows.map((data, idx) => {
     const cap = safeCaps[idx];
-    const rowCalcs: [number, number, number][] = []
+    const rowCalcs: [number, number, number, number][] = []
     const discountedConversionPPS = pricedConversion.pps * (1 - data.discount);
 
     let safePPS = discountedConversionPPS
@@ -82,6 +82,7 @@ export const calcSAFEs = (
       (safeShares / pricedConversion.postMoneyShares) * 100,
       cap,
       0,
+      safePPS
     ]);
 
     const pps = pricedConversion.ppss[idx];
@@ -90,6 +91,7 @@ export const calcSAFEs = (
       (shares / pricedConversion.totalShares) * 100,
       cap,
       shares,
+      pps
     ]);
 
     return rowCalcs;

--- a/src/library/safe_conversion.ts
+++ b/src/library/safe_conversion.ts
@@ -2,7 +2,7 @@ export interface ISafeInvestment {
   investment: number;
   discount: number;
   cap: number;
-  conversionType: "post" | "pre" | "mfn";
+  conversionType: "post" | "pre" | "mfn" | "yc7p" | "ycmfn";
 }
 
 export type BestFit = {


### PR DESCRIPTION
* Updated Selector for convertibles to always show "YC $125K/7%" and "YC $375K/MFN" through adding a new property called convertibleDisplay separate from convertibleType
* Removed box borders for input fields that are disabled.  Wasn't able to add the Italian-style bottom border only though. tailwind is a maze!