### PR TITLE
Align series selector with new library

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ If you're more comforable with a spreadsheet, we offer this script as a Google A
 1. Run the development server - `yarn dev`
 1. Visit the localhost server at http://localhost:3000/startup-finance/safe-conversion
 
+### Library
+
+The majority of the calculations and core work happen in the library. If you have issues with the underlying math and calculation,
+it's likely in the library. Please write a test showing the issue along with a proposed fix.
+
 ### Testing / Linting / Staging
 
 This library is tested using Jest, which you can run with `yarn test`

--- a/src/app/cap-table/state/ConversionState.ts
+++ b/src/app/cap-table/state/ConversionState.ts
@@ -59,7 +59,7 @@ function getNextIdx(rowData: IRowState[]) {
 
 function getRandomSeed(rowData: IRowState[]) {
   const existingNames = rowData
-    .filter((r) => r.type === "safe")
+    .filter((r) => r.type === CapTableRowType.Safe)
     .map((r) => r.name);
   const availableNames = randomSeed().filter((r) => !existingNames.includes(r));
   if (availableNames.length > 0) {
@@ -71,7 +71,7 @@ function getRandomSeed(rowData: IRowState[]) {
 
 function getRandomInvestor(rowData: IRowState[]) {
   const existingNames = rowData
-    .filter((r) => r.type === "series")
+    .filter((r) => r.type === CapTableRowType.Series)
     .map((r) => r.name);
   const availableNames = randomSeries().filter((r) => !existingNames.includes(r));
   if (availableNames.length > 0) {
@@ -83,7 +83,7 @@ function getRandomInvestor(rowData: IRowState[]) {
 
 function getRandomFounder(rowData: IRowState[]) {
   const existingNames = rowData
-    .filter((r) => r.type === "common")
+    .filter((r) => r.type === CapTableRowType.Common)
     .map((r) => r.name);
   const availableNames = randomFounders().filter(
     (r) => !existingNames.includes(r),
@@ -101,7 +101,7 @@ export const createConversionStore = (initialState: IConversionStateData) =>
   create<IConversionState>((set, get) => ({
     ...initialState,
 
-    onAddRow: (type: "safe" | "series" | "common") => {
+    onAddRow: (type: CapTableRowType.Common | CapTableRowType.Safe | CapTableRowType.Series) => {
       const idx = getNextIdx(get().rowData);
       if (type === CapTableRowType.Safe) {
         set((state) => ({

--- a/src/app/cap-table/state/ConversionState.ts
+++ b/src/app/cap-table/state/ConversionState.ts
@@ -103,7 +103,7 @@ export const createConversionStore = (initialState: IConversionStateData) =>
 
     onAddRow: (type: "safe" | "series" | "common") => {
       const idx = getNextIdx(get().rowData);
-      if (type === "safe") {
+      if (type === CapTableRowType.Safe) {
         set((state) => ({
           ...state,
           rowData: [
@@ -119,7 +119,7 @@ export const createConversionStore = (initialState: IConversionStateData) =>
             },
           ],
         }));
-      } else if (type === "common") {
+      } else if (type === CapTableRowType.Common) {
         set((state) => ({
           ...state,
           rowData: [
@@ -133,14 +133,14 @@ export const createConversionStore = (initialState: IConversionStateData) =>
             },
           ],
         }));
-      } else if (type === "series") {
+      } else if (type === CapTableRowType.Series) {
         set((state) => ({
           ...state,
           rowData: [
             ...state.rowData,
             {
               id: idx,
-              type: "series",
+              type: CapTableRowType.Series,
               name: getRandomInvestor(state.rowData),
               investment: 0,
             },

--- a/src/app/cap-table/state/selectors/CommonOnlyCapTableSelector.ts
+++ b/src/app/cap-table/state/selectors/CommonOnlyCapTableSelector.ts
@@ -11,7 +11,7 @@ export const getCommonOnlyCapTable = createSelector(
     rowData,
     unusedOptions
   ): ExistingShareholderProps[] => {
-    const commonRows = rowData.filter((row) => row.type === "common") as ExistingShareholderState[]
+    const commonRows = rowData.filter((row) => row.type === CapTableRowType.Common) as ExistingShareholderState[]
     const commonStock: CommonStockholder[] = (commonRows).map(
       (row) => {
         return {

--- a/src/app/cap-table/state/selectors/PreRoundCapTableSelector.ts
+++ b/src/app/cap-table/state/selectors/PreRoundCapTableSelector.ts
@@ -14,7 +14,7 @@ export const getPreRoundCapTable = createSelector(
     rowData,
     unusedOptions
   ): CapTableProps => {
-    const commonStock: CommonStockholder[] = (rowData.filter((row) => row.type === "common") as ExistingShareholderState[]).map(
+    const commonStock: CommonStockholder[] = (rowData.filter((row) => row.type === CapTableRowType.Common) as ExistingShareholderState[]).map(
       (row) => {
         return {
           name: row.name ?? "",
@@ -31,7 +31,7 @@ export const getPreRoundCapTable = createSelector(
       commonType: CommonRowType.UnusedOptions
     })
 
-    const safeNotes: SAFENote[] = (rowData.filter((row) => row.type === "safe") as SAFEState[]).map(
+    const safeNotes: SAFENote[] = (rowData.filter((row) => row.type === CapTableRowType.Safe) as SAFEState[]).map(
       (row) => {
         const conversionType = row.conversionType === "mfn" ? "post" : row.conversionType === 'post' ? "post" : "pre";
         return {
@@ -52,7 +52,7 @@ export const getPreRoundCapTable = createSelector(
       totalRow: total,
       changes: [],
       rows: [...common, ...safes].map((row) => {
-        if (row.type === 'common') {
+        if (row.type === CapTableRowType.Common) {
           return {
             id: row.id ?? "",
             name: row.name ?? "",

--- a/src/app/cap-table/state/selectors/PricedRoundSelector.ts
+++ b/src/app/cap-table/state/selectors/PricedRoundSelector.ts
@@ -17,7 +17,7 @@ export type ResultSelectorState = IConversionStateData & {
 
 const rowDataToStakeholders = (rowData: IRowState[]): (CommonStockholder | SAFENote | SeriesInvestor)[] => {
 
-    const commonStock: CommonStockholder[] = (rowData.filter((row) => row.type === "common") as ExistingShareholderState[]).map(
+    const commonStock: CommonStockholder[] = (rowData.filter((row) => row.type === CapTableRowType.Common) as ExistingShareholderState[]).map(
       (row) => {
         return {
           id: row.id,
@@ -29,7 +29,7 @@ const rowDataToStakeholders = (rowData: IRowState[]): (CommonStockholder | SAFEN
       }
     );
 
-    const safeNotes: SAFENote[] = (rowData.filter((row) => row.type === "safe") as SAFEState[]).map(
+    const safeNotes: SAFENote[] = (rowData.filter((row) => row.type === CapTableRowType.Safe) as SAFEState[]).map(
       (row) => {
         const conversionType = row.conversionType === "mfn" ? "post" : row.conversionType === 'post' ? "post" : "pre";
         return {
@@ -45,7 +45,7 @@ const rowDataToStakeholders = (rowData: IRowState[]): (CommonStockholder | SAFEN
       }
     );
 
-    const seriesInvestors: SeriesInvestor[] = rowData.filter((row) => row.type === "series").map(
+    const seriesInvestors: SeriesInvestor[] = rowData.filter((row) => row.type === CapTableRowType.Series).map(
       (row) => {
         return {
           id: row.id,
@@ -77,14 +77,14 @@ export const getPricedConversion = createSelector(
     }
     const commonStock = (
       rowData.filter(
-        (row) => row.type === "common",
+        (row) => row.type === CapTableRowType.Common,
       ) as ExistingShareholderState[]
     )
       .map((row) => row.shares)
       .reduce((acc, val) => acc + val, 0);
 
     const totalShares = commonStock;
-    const safeInvestors = rowData.filter((row) => row.type === "safe") as SAFEProps[];
+    const safeInvestors = rowData.filter((row) => row.type === CapTableRowType.Safe) as SAFEProps[];
     const pricedConversion = fitConversion(
       stringToNumber(preMoney),
       totalShares,
@@ -107,7 +107,7 @@ export const getPricedConversion = createSelector(
       ),
       stringToNumber(unusedOptions),
       stringToNumber(targetOptionsPool) / 100,
-      (rowData.filter((row) => row.type === "series") as SeriesProps[]).map(
+      (rowData.filter((row) => row.type === CapTableRowType.Series) as SeriesProps[]).map(
         (row) => row.investment,
       ),
       { roundShares: true, roundPPSPlaces: 8 },
@@ -152,13 +152,13 @@ export const getPricedRoundData = createSelector(
 
       // Get the Series Investments and distribute the investmentChange over the series investors pro rata
       const initialSeriesInvestment = rowData
-        .filter((row) => row.type === "series")
+        .filter((row) => row.type === CapTableRowType.Series)
         .map((row) => row.investment)
         .reduce((acc, val) => acc + val, 0);
 
       // Pro rata the investment change over the series investors
       const seriesInvestmentChanges = rowData.map((row) => {
-        if (row.type === "series") {
+        if (row.type === CapTableRowType.Series) {
           return investmentChange * (row.investment / initialSeriesInvestment);
         }
         return 0;
@@ -166,7 +166,7 @@ export const getPricedRoundData = createSelector(
 
       // Update the series investments with the above pro rata changes
       updatedRows = rowData.map((row, idx) => {
-        if (row.type === "series") {
+        if (row.type === CapTableRowType.Series) {
           return {
             ...row,
             investment: row.investment + seriesInvestmentChanges[idx],
@@ -231,7 +231,7 @@ export const getPricedRoundCapTableSelector = createSelector(
       totalRow: total,
       changes: ownershipChanges,
       rows: capTableRows.map((row) => {
-        if (row.type === 'safe') {
+        if (row.type === CapTableRowType.Safe) {
           return {
             name: row.name ?? "",
             shares: row.shares,
@@ -243,7 +243,7 @@ export const getPricedRoundCapTableSelector = createSelector(
             ownershipPct: (row.ownershipPct ?? 0) * 100,
           }
         }
-        if (row.type === 'series') {
+        if (row.type === CapTableRowType.Series) {
           const pps = row.pps
           const investment = row.investment
           return {
@@ -255,7 +255,7 @@ export const getPricedRoundCapTableSelector = createSelector(
             ownershipPct: (row.ownershipPct ?? 0) * 100,
           }
         }
-        if (row.type === 'common') {
+        if (row.type === CapTableRowType.Common) {
           return {
             name: row.name ?? "",
             shares: row.shares,
@@ -264,7 +264,7 @@ export const getPricedRoundCapTableSelector = createSelector(
             commonType: row.commonType,
           }
         }
-        if (row.type === 'refreshedOptions') {
+        if (row.type === CapTableRowType.RefreshedOptions) {
           return {
             name: row.name ?? "",
             shares: row.shares,

--- a/src/app/cap-table/state/selectors/SeriesPropsSelector.ts
+++ b/src/app/cap-table/state/selectors/SeriesPropsSelector.ts
@@ -8,24 +8,20 @@ export const getSeriesPropsSelector = createSelector(
   getPricedConversion,
   (state: IConversionStateData) => state.rowData,
   (pricedConversion, rowData): SeriesProps[] => {
-    const rows = rowData.filter((row) => row.type === "series");
-    const seriesOwnershipPct = rows.map((data) => {
-      if (!pricedConversion) return [0, 0];
-      const shares = Math.floor(data.investment / pricedConversion.pps);
-      return [shares, (shares / pricedConversion.totalShares) * 100, pricedConversion.pps];
-    });
+    const rows = rowData.filter((row) => row.type === CapTableRowType.Series);
+    if (!pricedConversion) throw new Error("Priced conversion not found");
 
-    return rows.map((row, idx) => {
+    return rows.map((row) => {
+      const shares = Math.floor(row.investment / pricedConversion.pps) * 100;
+      const ownershipPct = shares / pricedConversion.totalShares;
       return {
         id: row.id,
         type: CapTableRowType.Series,
         name: row.name,
         investment: row.investment,
-        ownership: [{
-          shares: seriesOwnershipPct[idx][0] ?? 0,
-          percent: seriesOwnershipPct[idx][1] ?? 0,
-          pps: seriesOwnershipPct[idx][2] ?? 0,
-        }],
+        shares,
+        ownershipPct,
+        pps: pricedConversion.pps,
         allowDelete: rows.length > 1,
       };
     });

--- a/src/app/cap-table/state/selectors/SeriesPropsSelector.ts
+++ b/src/app/cap-table/state/selectors/SeriesPropsSelector.ts
@@ -12,8 +12,8 @@ export const getSeriesPropsSelector = createSelector(
     if (!pricedConversion) throw new Error("Priced conversion not found");
 
     return rows.map((row) => {
-      const shares = Math.floor(row.investment / pricedConversion.pps) * 100;
-      const ownershipPct = shares / pricedConversion.totalShares;
+      const shares = Math.floor(row.investment / pricedConversion.pps);
+      const ownershipPct = shares / pricedConversion.totalShares * 100;
       return {
         id: row.id,
         type: CapTableRowType.Series,

--- a/src/app/cap-table/state/selectors/__tests__/PricedRoundSelector.test.ts
+++ b/src/app/cap-table/state/selectors/__tests__/PricedRoundSelector.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@/cap-table/state/ConversionState";
 import fixtureData from "../../__tests__/fixtures/state_fixtures.json";
 import { getPricedRoundCapTableSelector } from "../PricedRoundSelector";
+import { CapTableRowType } from "@library/cap-table";
 
 // Test our Result Selector, which handles both showing the resulting cap table and allow users to play around with the pre-money and investment changes
 describe("Result Selector", () => {
@@ -15,7 +16,7 @@ describe("Result Selector", () => {
       preMoneyChange: 0,
       investmentChange: 0,
     });
-    const investors = resultSelector.rows.filter((row) => row.type === 'safe' || row.type === 'series')
+    const investors = resultSelector.rows.filter((row) => row.type === CapTableRowType.Safe || row.type === CapTableRowType.Series)
     const totalInvestment = investors.reduce((sum, current) => sum + current.investment, 0);
     expect(resultSelector.totalRow.investment).toEqual(totalInvestment);
   });

--- a/src/app/components/safe-conversion/Conversion/CapTableResults.tsx
+++ b/src/app/components/safe-conversion/Conversion/CapTableResults.tsx
@@ -1,5 +1,5 @@
 import { formatNumberWithCommas } from "@library/utils/numberFormatting";
-import { CapTableRow, TotalCapTableRow } from "@library/cap-table";
+import { CapTableRow, CapTableRowType, TotalCapTableRow } from "@library/cap-table";
 
 export type CapTableProps = {
   rows: CapTableRow[];
@@ -19,8 +19,8 @@ const roundTo = (num: number, decimal: number): number => {
 };
 
 const CapTableRowItem: React.FC<CapTableRowItemProps> = ({shareholder, change }) => {
-  const investment = (shareholder.type === "safe" || shareholder.type === "series") ? shareholder.investment : null
-  const pps = (shareholder.type === "safe" || shareholder.type === "series") ? shareholder.pps : null
+  const investment = (shareholder.type === CapTableRowType.Safe || shareholder.type === CapTableRowType.Series) ? shareholder.investment : null
+  const pps = (shareholder.type === CapTableRowType.Safe || shareholder.type === CapTableRowType.Series) ? shareholder.pps : null
 
   const hasChanges = change !== undefined
   const changePct = roundTo((change ?? 0) * 100, 2)

--- a/src/app/components/safe-conversion/Conversion/ExistingShareholders.tsx
+++ b/src/app/components/safe-conversion/Conversion/ExistingShareholders.tsx
@@ -6,8 +6,8 @@ import QuestionMarkTooltipComponent from "@/components/tooltip/QuestionMarkToolt
 import { CommonCapTableRow } from "@library/cap-table";
 
 export type ExistingShareholderProps = CommonCapTableRow & {
+  // We need to ensure we can identify the row when updating or deleting
   id: string;
-  allowDelete?: boolean;
 }
 
 interface ExistingShareholderRowProps {

--- a/src/app/components/safe-conversion/Conversion/Finder.tsx
+++ b/src/app/components/safe-conversion/Conversion/Finder.tsx
@@ -4,6 +4,7 @@ import { getRecentStates } from "@/cap-table/state/localstorage";
 import { compressState } from "@/utils/stateCompression";
 import { IConversionStateData } from "@/cap-table/state/ConversionState";
 import { shortenedUSD } from "@library/utils/numberFormatting";
+import { CapTableRowType } from "@library/cap-table";
 
 // Get a list of recent states from local storage
 // Also allow for a reset of the recent states
@@ -38,8 +39,8 @@ const Finder: React.FC<{currentId: string, loadById: (id: string) => void}> = ({
   };
 
   const describeCapTable = (state: IConversionStateData) => {
-    const safeInvestments = state.rowData.filter((row) => row.type === "safe").map((row) => row.investment).reduce((acc, val) => acc + val, 0);
-    const safeCount = state.rowData.filter((row) => row.type === "safe").length;
+    const safeInvestments = state.rowData.filter((row) => row.type === CapTableRowType.Safe).map((row) => row.investment).reduce((acc, val) => acc + val, 0);
+    const safeCount = state.rowData.filter((row) => row.type === CapTableRowType.Safe).length;
     return `${safeCount} SAFE${ safeCount === 1 ? "" : "'s"} totaling ${shortenedUSD(safeInvestments)}`;
   }
 

--- a/src/app/components/safe-conversion/Conversion/SafeNoteList.tsx
+++ b/src/app/components/safe-conversion/Conversion/SafeNoteList.tsx
@@ -12,7 +12,6 @@ export type SAFEProps = SafeCapTableRow & {
   name: string;
   // Legacy where we used to allow specific version of SAFE
   conversionType: "post" | "pre" | "mfn" | "yc7p" | "ycmfn";
-  sideLetters?: ['mfn'];
   allowDelete?: boolean;
   disabledFields?: string[];
 }

--- a/src/app/components/safe-conversion/Conversion/SeriesInvestorList.tsx
+++ b/src/app/components/safe-conversion/Conversion/SeriesInvestorList.tsx
@@ -2,19 +2,12 @@ import React from "react";
 import CurrencyInput from "react-currency-input-field";
 import { RowsProps } from "./PropTypes";
 import { XCircleIcon } from "@heroicons/react/24/outline";
+import { SeriesCapTableRow } from "@library/cap-table";
 
-export interface SeriesProps {
+export type SeriesProps = SeriesCapTableRow & {
   id: string;
-  type: "series";
   name: string;
   investment: number;
-  ownership: {
-    shares?: number;
-    percent: number;
-    pps: number;
-    error?: string | undefined;
-    reason?: string | undefined;
-  }[];
   allowDelete?: boolean;
 }
 
@@ -78,7 +71,7 @@ const SeriesInvestorRow: React.FC<SeriesRowProps> = ({
         prefix="$"
         decimalScale={0}
       />
-      <div className="w-24 text-right">{data.ownership[0].percent.toFixed(2)}%</div>
+      <div className="w-24 text-right">{data.ownershipPct.toFixed(2)}%</div>
     </div>
   );
 };

--- a/src/library/__tests__/cap-table/pre-round.test.ts
+++ b/src/library/__tests__/cap-table/pre-round.test.ts
@@ -113,7 +113,7 @@ describe("Building an estimated pre-round cap table with common shareholders and
 
     // We use a "fake" priced round with no additional options to estimate the pre-money conversion
     // As long as the priced-round is at a valuation higher than the cap, this will be an accurate pre-money value
-    expect(safes[2].type === 'safe' && safes[2].ownershipPct?.toFixed(5)).toEqual("0.07727");
+    expect(safes[2].type === CapTableRowType.Safe && safes[2].ownershipPct?.toFixed(5)).toEqual("0.07727");
 
   });
 });
@@ -137,8 +137,8 @@ describe("Building a priced-round pre-round cap table with common shareholders, 
   // This is different than the priced-round cap table because it's the cap table excluding the new series investors and additional options refresh
   test("Pre-round cap table with pre-money SAFE should be the same as the estimate", () => {
     const premoney = 25_000_000;
-    const commonShares = commonFixture.filter(row => row.type === "common" && row.commonType === 'shareholder').reduce((acc, row) => acc + row.shares, 0);
-    const unusedOptions = commonFixture.filter(row => row.type === "common" && row.commonType === 'unusedOptions').reduce((acc, row) => acc + row.shares, 0);
+    const commonShares = commonFixture.filter(row => row.type === CapTableRowType.Common && row.commonType === CommonRowType.Shareholder).reduce((acc, row) => acc + row.shares, 0);
+    const unusedOptions = commonFixture.filter(row => row.type === CapTableRowType.Common && row.commonType === CommonRowType.UnusedOptions).reduce((acc, row) => acc + row.shares, 0);
 
     const pricedConversion = fitConversion(premoney, commonShares, safeFixtureWithPreMoney, unusedOptions, 0.0, [
       seriesFixture[0].investment,
@@ -151,6 +151,6 @@ describe("Building a priced-round pre-round cap table with common shareholders, 
     crossCheckCapTableResults([...common, ...safes], total);
 
     // Should match our ownership pct from the estimated round because we didn't add additional options
-    expect(safes[2].type === 'safe' && safes[2].ownershipPct?.toFixed(8)).toEqual("0.07727277");
+    expect(safes[2].type === CapTableRowType.Safe && safes[2].ownershipPct?.toFixed(8)).toEqual("0.07727277");
   });
 });

--- a/src/library/__tests__/cap-table/priced-round.test.ts
+++ b/src/library/__tests__/cap-table/priced-round.test.ts
@@ -67,8 +67,8 @@ const seriesFixture: SeriesInvestor[] = [
 describe("Building a priced-round cap table with common shareholders, SAFE notes, and priced round investors", () => {
   test("Sanity check our baseline", () => {
     const premoney = 25_000_000;
-    const commonShares = commonFixture.filter(row => row.type === "common" && row.commonType === 'shareholder').reduce((acc, row) => acc + row.shares, 0);
-    const unusedOptions = commonFixture.filter(row => row.type === "common" && row.commonType === 'unusedOptions').reduce((acc, row) => acc + row.shares, 0);
+    const commonShares = commonFixture.filter(row => row.type === CapTableRowType.Common && row.commonType === CommonRowType.Shareholder).reduce((acc, row) => acc + row.shares, 0);
+    const unusedOptions = commonFixture.filter(row => row.type === CapTableRowType.Common && row.commonType === CommonRowType.UnusedOptions).reduce((acc, row) => acc + row.shares, 0);
 
     const pricedConversion = fitConversion(premoney, commonShares, safeFixture, unusedOptions, 0.1, [
       seriesFixture[0].investment,

--- a/src/library/__tests__/cap-table/utils.ts
+++ b/src/library/__tests__/cap-table/utils.ts
@@ -1,9 +1,9 @@
 import { expect } from "@jest/globals";
-import { CapTableRow, TotalCapTableRow, SafeCapTableRow, SeriesCapTableRow } from "@library/cap-table";
+import { CapTableRow, TotalCapTableRow, SafeCapTableRow, SeriesCapTableRow, CapTableRowType } from "@library/cap-table";
 import { roundToPlaces } from "@library/utils/rounding";
 
 export const crossCheckCapTableResults = (rows: CapTableRow[], total: TotalCapTableRow) => {
-  const investors = rows.filter(row => (row.type === 'safe' || row.type === 'series')) as (SafeCapTableRow | SeriesCapTableRow)[];
+  const investors = rows.filter(row => (row.type === CapTableRowType.Safe || row.type === CapTableRowType.Series)) as (SafeCapTableRow | SeriesCapTableRow)[];
   const investedTotal = investors.reduce((acc, row) => acc + (row.investment ?? 0), 0);
   expect(investedTotal).toEqual(total.investment);
 

--- a/src/library/cap-table/pre-round.ts
+++ b/src/library/cap-table/pre-round.ts
@@ -11,13 +11,13 @@ import { formatUSDWithCommas } from "@library/utils/numberFormatting";
 // 2. Round entirely TBD because no max cap
 // 3. Error due to some non-sensical input (investment exceeds cap)
 export const buildEstimatedPreRoundCapTable = (stakeHolders: StakeHolder[], roundingStrategy: RoundingStrategy = DEFAULT_ROUNDING_STRATEGY): {common: CommonCapTableRow[], safes: SafeCapTableRow[], total: TotalCapTableRow} => {
-  const commonShareholders = stakeHolders.filter((stakeHolder) => stakeHolder.type === "common") as CommonStockholder[];
+  const commonShareholders = stakeHolders.filter((stakeHolder) => stakeHolder.type === CapTableRowType.Common) as CommonStockholder[];
 
   // The premoney shares are used to determine the pre-money safe conversions (SAFE cap / PreMoneyShares)
   const preMoneyShares = commonShareholders.reduce((acc, stockholder) => acc + stockholder.shares, 0);
 
   // Handle any MFN side-letters and find the following best cap
-  const safeNotes = populateSafeCaps(stakeHolders.filter((stakeHolder) => stakeHolder.type === "safe") as SAFENote[])
+  const safeNotes = populateSafeCaps(stakeHolders.filter((stakeHolder) => stakeHolder.type === CapTableRowType.Safe) as SAFENote[])
 
   // Handle Error, just stop here and generate an error cap table
   if (safeNotes.some((safeNote) => safeNote.cap !== 0 && safeNote.cap <= safeNote.investment)) {
@@ -161,8 +161,8 @@ export const buildEstimatedPreRoundCapTable = (stakeHolders: StakeHolder[], roun
 
 // Build a pre-round cap table once we have a pricedRound to convert at
 export const buildPreRoundCapTable = (pricedConversion: BestFit, stakeHolders: StakeHolder[]): {common: CommonCapTableRow[], safes: SafeCapTableRow[], total: TotalCapTableRow} => {
-  const commonShareholders = stakeHolders.filter((stakeHolder) => stakeHolder.type === "common") as CommonStockholder[];
-  const safeNotes = populateSafeCaps(stakeHolders.filter((stakeHolder) => stakeHolder.type === "safe") as SAFENote[])
+  const commonShareholders = stakeHolders.filter((stakeHolder) => stakeHolder.type === CapTableRowType.Common) as CommonStockholder[];
+  const safeNotes = populateSafeCaps(stakeHolders.filter((stakeHolder) => stakeHolder.type === CapTableRowType.Safe) as SAFENote[])
   const totalShares = pricedConversion.totalShares - pricedConversion.seriesShares - pricedConversion.additionalOptions;
 
   const totalInvestment = [...safeNotes].reduce((acc, investor) => acc + investor.investment, 0);

--- a/src/library/cap-table/priced-round.ts
+++ b/src/library/cap-table/priced-round.ts
@@ -1,6 +1,6 @@
 import { BestFit } from "@library/conversion-solver";
 import { roundShares } from "@library/utils/rounding";
-import { StakeHolder, CommonCapTableRow, SafeCapTableRow, SeriesCapTableRow, RefreshedOptionsCapTableRow, TotalCapTableRow, CapTableOwnershipError, CommonStockholder, SAFENote, SeriesInvestor, CapTableRowType } from ".";
+import { StakeHolder, CommonCapTableRow, SafeCapTableRow, SeriesCapTableRow, RefreshedOptionsCapTableRow, TotalCapTableRow, CapTableOwnershipError, CommonStockholder, SAFENote, SeriesInvestor, CapTableRowType, CommonRowType } from ".";
 
 
 export const buildPricedRoundCapTable = (pricedConversion: BestFit, stakeHolders: StakeHolder[]): 
@@ -12,9 +12,9 @@ export const buildPricedRoundCapTable = (pricedConversion: BestFit, stakeHolders
     total: TotalCapTableRow,
     error?: CapTableOwnershipError
   } => {
-  const commonShareholders = stakeHolders.filter((stakeHolder) => stakeHolder.type === "common" && stakeHolder.commonType !== 'unusedOptions') as CommonStockholder[];
-  const safeNotes = stakeHolders.filter((stakeHolder) => stakeHolder.type === "safe") as SAFENote[];
-  const seriesInvestors = stakeHolders.filter((stakeHolder) => stakeHolder.type === "series") as SeriesInvestor[];
+  const commonShareholders = stakeHolders.filter((stakeHolder) => stakeHolder.type === CapTableRowType.Common && stakeHolder.commonType !== CommonRowType.UnusedOptions) as CommonStockholder[];
+  const safeNotes = stakeHolders.filter((stakeHolder) => stakeHolder.type === CapTableRowType.Safe) as SAFENote[];
+  const seriesInvestors = stakeHolders.filter((stakeHolder) => stakeHolder.type === CapTableRowType.Series) as SeriesInvestor[];
   const totalShares = pricedConversion.totalShares;
 
   const totalInvestment = [...seriesInvestors, ...safeNotes].reduce((acc, investor) => acc + investor.investment, 0);


### PR DESCRIPTION
<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Cal</h3></i></summary>

## PR Description
This PR updates the codebase to align with a new library by replacing string literals representing row types with the `CapTableRowType` enum. This change affects multiple files across the project, ensuring consistency and reducing potential errors related to string literals.

### Key Issues
None

## Files Changed
<details>
				<summary>File: <b>/README.md</b></summary>
				Added a section about the library, explaining where the core calculations occur and how to address issues.
			</details><details>
				<summary>File: <b>/src/app/cap-table/state/ConversionState.ts</b></summary>
				Replaced string literals for row types with `CapTableRowType` enum in various functions and methods.
			</details><details>
				<summary>File: <b>/src/app/cap-table/state/selectors/CommonOnlyCapTableSelector.ts</b></summary>
				Updated the filter condition to use `CapTableRowType.Common` instead of a string literal.
			</details><details>
				<summary>File: <b>/src/app/cap-table/state/selectors/PreRoundCapTableSelector.ts</b></summary>
				Replaced string literals for row types with `CapTableRowType` enum in the selector logic.
			</details><details>
				<summary>File: <b>/src/app/cap-table/state/selectors/PricedRoundSelector.ts</b></summary>
				Updated the filtering logic to use `CapTableRowType` enum for row types.
			</details><details>
				<summary>File: <b>/src/app/cap-table/state/selectors/SeriesPropsSelector.ts</b></summary>
				Replaced string literals for row types with `CapTableRowType` enum and refactored ownership calculation.
			</details><details>
				<summary>File: <b>/src/app/cap-table/state/selectors/__tests__/PricedRoundSelector.test.ts</b></summary>
				Updated test cases to use `CapTableRowType` enum for row types.
			</details><details>
				<summary>File: <b>/src/app/components/safe-conversion/Conversion/CapTableResults.tsx</b></summary>
				Replaced string literals for row types with `CapTableRowType` enum in component logic.
			</details><details>
				<summary>File: <b>/src/app/components/safe-conversion/Conversion/ExistingShareholders.tsx</b></summary>
				Minor change to ensure row identification during updates or deletions.
			</details><details>
				<summary>File: <b>/src/app/components/safe-conversion/Conversion/Finder.tsx</b></summary>
				Updated filtering logic to use `CapTableRowType.Safe` for row types.
			</details><details>
				<summary>File: <b>/src/app/components/safe-conversion/Conversion/SafeNoteList.tsx</b></summary>
				Removed unused `sideLetters` property from `SAFEProps` type.
			</details><details>
				<summary>File: <b>/src/app/components/safe-conversion/Conversion/SeriesInvestorList.tsx</b></summary>
				Refactored `SeriesProps` type and updated ownership percentage calculation.
			</details><details>
				<summary>File: <b>/src/library/__tests__/cap-table/pre-round.test.ts</b></summary>
				Updated test cases to use `CapTableRowType` enum for row types.
			</details><details>
				<summary>File: <b>/src/library/__tests__/cap-table/priced-round.test.ts</b></summary>
				Updated test cases to use `CapTableRowType` enum for row types.
			</details><details>
				<summary>File: <b>/src/library/__tests__/cap-table/utils.ts</b></summary>
				Updated utility function to use `CapTableRowType` enum for row types.
			</details><details>
				<summary>File: <b>/src/library/cap-table/pre-round.ts</b></summary>
				Replaced string literals for row types with `CapTableRowType` enum in pre-round cap table logic.
			</details><details>
				<summary>File: <b>/src/library/cap-table/priced-round.ts</b></summary>
				Replaced string literals for row types with `CapTableRowType` enum in priced-round cap table logic.
			</details>

</details>
<!-- cal_description_end -->






